### PR TITLE
Fix for scripts and cmake

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,9 @@ ROOT_PATH=`pwd`
 mkdir -p .tmp
 
 # download oneDNN
+if [ ! -d $INSTALL_PREFIX_PATH ]; then
+    mkdir -p $INSTALL_PREFIX_PATH
+fi
 cd $INSTALL_PREFIX_PATH
 mkdir -p oneDNN
 cd oneDNN

--- a/tfcc/CMakeLists.txt
+++ b/tfcc/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 include(Utils)
 
 option(TFCC_WITH_MKL "Build tfcc_mkl" ON)
-option(TFCC_WITH_CUDA "Build tfcc_mkl" ON)
+option(TFCC_WITH_CUDA "Build tfcc_cuda" ON)
 option(TFCC_OPEN_COVERAGE "Build with coverage flags" OFF)
 option(TFCC_WITH_TEST "Build tfcc tests" ON)
 set(TFCC_EXTRA_CXX_FLAGS CACHE STRING "C++ extra build flags")


### PR DESCRIPTION
Some small fix to the installation script.
The prefix path should be checked before cd.